### PR TITLE
Embed badges bits patch

### DIFF
--- a/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadArgs.cs
@@ -19,16 +19,16 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option('e', "ending", HelpText = "Time in seconds to crop ending.")]
         public int CropEndingTime { get; set; }
         
-        [Option('E', "embed-emotes", Default = false, HelpText = "Embed emotes into the chat download.")]
-        public bool EmbedEmotes { get; set; }
+        [Option('E', "embed-images", Default = false, HelpText = "Embed first party emotes, badges, and cheermotes into the chat download for offline rendering.")]
+        public bool EmbedData { get; set; }
 
-        [Option("bttv", Default = true, HelpText = "Enable BTTV embedding in chat download. Requires -E / --embed-emotes!")]
+        [Option("bttv", Default = true, HelpText = "Enable BTTV embedding in chat download. Requires -E / --embed-images!")]
         public bool? BttvEmotes { get; set; }
         
-        [Option("ffz", Default = true, HelpText = "Enable FFZ embedding in chat download. Requires -E / --embed-emotes!")]
+        [Option("ffz", Default = true, HelpText = "Enable FFZ embedding in chat download. Requires -E / --embed-images!")]
         public bool? FfzEmotes { get; set; }
         
-        [Option("stv", Default = true, HelpText = "Enable 7tv embedding in chat download. Requires -E / --embed-emotes!")]
+        [Option("stv", Default = true, HelpText = "Enable 7tv embedding in chat download. Requires -E / --embed-images!")]
         public bool? StvEmotes { get; set; }
 
         [Option("timestamp", Default = false, HelpText = "Enable timestamps for .txt chat downloads.")]

--- a/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadUpdaterArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ChatDownloadUpdaterArgs.cs
@@ -1,23 +1,22 @@
 ﻿using CommandLine;
-using TwitchDownloaderCore.Options;
 
 namespace TwitchDownloaderCLI.Modes.Arguments
 {
 
-    [Verb("chatdownloadupdater", HelpText = "Will update the embeded emotes, badges, and bits.")]
+    [Verb("chatupdate", HelpText = "Updates the embeded emotes, badges, and bits of a chat download.")]
     public class ChatDownloadUpdaterArgs
     {
-        [Option('i', "input", Required = true, HelpText = "Path to input file. Valid extensions are json and html")]
+        [Option('i', "input", Required = true, HelpText = "Path to input file. Valid extensions are json")]
         public string InputFile { get; set; }
 
-        [Option('o', "output", Required = true, HelpText = "Path to output file. Format should match the input.")]
+        [Option('o', "output", Required = true, HelpText = "Path to output file. Extension should match the input.")]
         public string OutputFile { get; set; }
 
-        [Option('E', "embed-missing-emotes", Default = true, HelpText = "Embed emotes any emotes that are missing (keeps old ones and only appends)")]
-        public bool EmbedMissingEmotes { get; set; }
+        [Option('E', "embed-missing", Default = true, HelpText = "Embed missing emotes, badges, and bits. Already embedded images will be untouched")]
+        public bool EmbedMissing { get; set; }
 
-        [Option('U', "update-old-emotes", Default = false, HelpText = "Update old emotes to the current new ones (will overwrite them)")]
-        public bool UpdateOldEmotes { get; set; }
+        [Option('U', "update-old", Default = false, HelpText = "Update old emotes, badges, and bits to the current. All embedded images will be overwritten")]
+        public bool UpdateOldEmbeds { get; set; }
 
         [Option("bttv", Default = true, HelpText = "Enable BTTV embedding in chat download.")]
         public bool BttvEmotes { get; set; }
@@ -28,5 +27,7 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option("stv", Default = true, HelpText = "Enable 7tv embedding in chat download.")]
         public bool StvEmotes { get; set; }
 
+        [Option("temp-path", Default = "", HelpText = "Path to temporary folder to use for cache.")]
+        public string TempFolder { get; set; }
     }
 }

--- a/TwitchDownloaderCLI/Modes/Arguments/ChatRenderArgs.cs
+++ b/TwitchDownloaderCLI/Modes/Arguments/ChatRenderArgs.cs
@@ -81,13 +81,13 @@ namespace TwitchDownloaderCLI.Modes.Arguments
         [Option("badge-filter", Default = 0, HelpText = "Bitmask of types of Chat Badges to filter out. Add the numbers of the types of badges you want to filter. For example, 6 = no broadcaster or moderator badges.\r\nKey: Other = 1, Broadcaster = 2, Moderator = 4, VIP = 8, Subscriber = 16, Predictions = 32, NoAudio/NoVideo = 64, PrimeGaming = 128")]
         public int BadgeFilterMask { get; set; }
 
+        [Option("offline", Default = false, HelpText = "Render completely offline, using only resources embedded emotes, badges, and bits in the input json.")]
+        public bool Offline { get; set; }
+
         [Option("ffmpeg-path", HelpText = "Path to ffmpeg executable.")]
         public string FfmpegPath { get; set; }
 
         [Option("temp-path", Default = "", HelpText = "Path to temporary folder to use for cache.")]
         public string TempFolder { get; set; }
-
-        [Option("offline", Default = false, HelpText = "Enable to render without pulling latest emotes, badges, and bits.")]
-        public bool Offline { get; set; }
     }
 }

--- a/TwitchDownloaderCLI/Modes/DownloadChat.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadChat.cs
@@ -33,7 +33,7 @@ namespace TwitchDownloaderCLI.Modes
                 CropEnding = inputOptions.CropEndingTime > 0.0,
                 CropEndingTime = inputOptions.CropEndingTime,
                 Timestamp = inputOptions.Timestamp,
-                EmbedEmotes = inputOptions.EmbedEmotes,
+                EmbedData = inputOptions.EmbedData,
                 Filename = inputOptions.OutputFile,
                 TimeFormat = inputOptions.TimeFormat,
                 ConnectionCount = inputOptions.ChatConnections,

--- a/TwitchDownloaderCLI/Modes/DownloadChatUpdater.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadChatUpdater.cs
@@ -2,13 +2,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.Json;
-using Newtonsoft.Json;
-using System.Threading;
 using System.Threading.Tasks;
 using TwitchDownloaderCLI.Modes.Arguments;
-using TwitchDownloaderCLI.Tools;
 using TwitchDownloaderCore;
 using TwitchDownloaderCore.Options;
 using TwitchDownloaderCore.TwitchObjects;
@@ -19,8 +15,6 @@ namespace TwitchDownloaderCLI.Modes
     {
         internal static void Update(ChatDownloadUpdaterArgs inputOptions)
         {
-
-            // Check that both input and output are 
             DownloadFormat inFormat = Path.GetExtension(inputOptions.InputFile)!.ToLower() switch
             {
                 ".json" => DownloadFormat.Json,
@@ -35,9 +29,10 @@ namespace TwitchDownloaderCLI.Modes
                 ".htm" => DownloadFormat.Html,
                 _ => DownloadFormat.Text
             };
+            // Check that both input and output are json
             if (inFormat != DownloadFormat.Json || outFormat != DownloadFormat.Json)
             {
-                Console.WriteLine("[ERROR] - Format much only be JSON");
+                Console.WriteLine("[ERROR] - {0} format must be be json!", inFormat != DownloadFormat.Json ? "Input" : "Output");
                 Environment.Exit(1);
             }
             if (!File.Exists(inputOptions.InputFile))
@@ -45,62 +40,38 @@ namespace TwitchDownloaderCLI.Modes
                 Console.WriteLine("[ERROR] - Input file does not exist!");
                 Environment.Exit(1);
             }
-            if (!inputOptions.EmbedMissingEmotes && !inputOptions.UpdateOldEmotes)
+            if (!inputOptions.EmbedMissing && !inputOptions.UpdateOldEmbeds)
             {
                 Console.WriteLine("[ERROR] - Please enable either EmbedMissingEmotes or UpdateOldEmotes");
                 Environment.Exit(1);
             }
 
             // Read in the old input file
-            // TODO: to be honest, this should just be copied here, we should instead use a function
-            // TODO: that can be shared by the ChatRenderer file which also needs to open this file...
-            ChatRoot chatRoot = new ChatRoot();
-            using (FileStream fs = new FileStream(inputOptions.InputFile, FileMode.Open, FileAccess.Read))
-            {
-                using (var jsonDocument = JsonDocument.Parse(fs))
-                {
-                    if (jsonDocument.RootElement.TryGetProperty("streamer", out JsonElement streamerJson))
-                    {
-                        chatRoot.streamer = streamerJson.Deserialize<Streamer>();
-                    }
-                    if (jsonDocument.RootElement.TryGetProperty("video", out JsonElement videoJson))
-                    {
-                        if (videoJson.TryGetProperty("start", out JsonElement videoStartJson) && videoJson.TryGetProperty("end", out JsonElement videoEndJson))
-                        {
-                            chatRoot.video = videoJson.Deserialize<VideoTime>();
-                        }
-                    }
-                    if (jsonDocument.RootElement.TryGetProperty("emotes", out JsonElement emotesJson))
-                    {
-                        chatRoot.emotes = emotesJson.Deserialize<Emotes>();
-                    }
-                    if (jsonDocument.RootElement.TryGetProperty("comments", out JsonElement commentsJson))
-                    {
-                        chatRoot.comments = commentsJson.Deserialize<List<Comment>>();
-                    }
-                }
-            }
+            ChatRoot chatRoot = Task.Run(() => ChatRenderer.ParseJsonStatic(inputOptions.InputFile)).Result;
             if (chatRoot.streamer == null)
             {
                 chatRoot.streamer = new Streamer();
                 chatRoot.streamer.id = int.Parse(chatRoot.comments.First().channel_id);
                 chatRoot.streamer.name = Task.Run(() => TwitchHelper.GetStreamerName(chatRoot.streamer.id)).Result;
             }
-            if (chatRoot.emotes == null)
+            if (chatRoot.embeddedData == null)
             {
-                chatRoot.emotes = new Emotes();
+                chatRoot.embeddedData = new EmbeddedData();
             }
 
-            string cacheFolder = Path.Combine(Path.GetTempPath(), "TwitchDownloader", "cache");
+            string cacheFolder = Path.Combine(string.IsNullOrWhiteSpace(inputOptions.TempFolder) ? Path.GetTempPath() : inputOptions.TempFolder, "TwitchDownloader", "chatupdatecache");
+
+            if (Directory.Exists(cacheFolder))
+                Directory.Delete(cacheFolder, true);
 
             // Thirdparty emotes
-            if(chatRoot.emotes.thirdParty == null || inputOptions.UpdateOldEmotes)
+            if (chatRoot.embeddedData.thirdParty == null || inputOptions.UpdateOldEmbeds)
             {
-                chatRoot.emotes.thirdParty = new List<EmbedEmoteData>();
+                chatRoot.embeddedData.thirdParty = new List<EmbedEmoteData>();
             }
-            Console.WriteLine("Thirdparty: Before " + chatRoot.emotes.thirdParty.Count);
+            Console.WriteLine("Input third party emote count: " + chatRoot.embeddedData.thirdParty.Count);
             List<TwitchEmote> thirdPartyEmotes = new List<TwitchEmote>();
-            thirdPartyEmotes = Task.Run(() => TwitchHelper.GetThirdPartyEmotes(chatRoot.streamer.id, cacheFolder, bttv: inputOptions.BttvEmotes, ffz: inputOptions.FfzEmotes, stv: inputOptions.StvEmotes, embededEmotes: chatRoot.emotes)).Result;
+            thirdPartyEmotes = Task.Run(() => TwitchHelper.GetThirdPartyEmotes(chatRoot.streamer.id, cacheFolder, bttv: inputOptions.BttvEmotes, ffz: inputOptions.FfzEmotes, stv: inputOptions.StvEmotes, embededData: chatRoot.embeddedData)).Result;
             foreach (TwitchEmote emote in thirdPartyEmotes)
             {
                 EmbedEmoteData newEmote = new EmbedEmoteData();
@@ -110,18 +81,18 @@ namespace TwitchDownloaderCLI.Modes
                 newEmote.name = emote.Name;
                 newEmote.width = emote.Width / emote.ImageScale;
                 newEmote.height = emote.Height / emote.ImageScale;
-                chatRoot.emotes.thirdParty.Add(newEmote);
+                chatRoot.embeddedData.thirdParty.Add(newEmote);
             }
-            Console.WriteLine("Thirdparty: After " + chatRoot.emotes.thirdParty.Count);
+            Console.WriteLine("Output third party emote count: " + chatRoot.embeddedData.thirdParty.Count);
 
             // Firstparty emotes
-            if (chatRoot.emotes.firstParty == null || inputOptions.UpdateOldEmotes)
+            if (chatRoot.embeddedData.firstParty == null || inputOptions.UpdateOldEmbeds)
             {
-                chatRoot.emotes.firstParty = new List<EmbedEmoteData>();
+                chatRoot.embeddedData.firstParty = new List<EmbedEmoteData>();
             }
-            Console.WriteLine("Firstparty: Before " + chatRoot.emotes.firstParty.Count);
+            Console.WriteLine("Input first party emote count: " + chatRoot.embeddedData.firstParty.Count);
             List<TwitchEmote> firstPartyEmotes = new List<TwitchEmote>();
-            firstPartyEmotes = Task.Run(() => TwitchHelper.GetEmotes(chatRoot.comments, cacheFolder, embededEmotes: chatRoot.emotes)).Result;
+            firstPartyEmotes = Task.Run(() => TwitchHelper.GetEmotes(chatRoot.comments, cacheFolder, embededData: chatRoot.embeddedData)).Result;
             foreach (TwitchEmote emote in firstPartyEmotes)
             {
                 EmbedEmoteData newEmote = new EmbedEmoteData();
@@ -130,35 +101,35 @@ namespace TwitchDownloaderCLI.Modes
                 newEmote.data = emote.ImageData;
                 newEmote.width = emote.Width / emote.ImageScale;
                 newEmote.height = emote.Height / emote.ImageScale;
-                chatRoot.emotes.firstParty.Add(newEmote);
+                chatRoot.embeddedData.firstParty.Add(newEmote);
             }
-            Console.WriteLine("Firstparty: After " + chatRoot.emotes.firstParty.Count);
+            Console.WriteLine("Output third party emote count: " + chatRoot.embeddedData.firstParty.Count);
 
             // Twitch badges
-            if (chatRoot.emotes.twitchBadges == null || inputOptions.UpdateOldEmotes)
+            if (chatRoot.embeddedData.twitchBadges == null || inputOptions.UpdateOldEmbeds)
             {
-                chatRoot.emotes.twitchBadges = new List<EmbedChatBadge>();
+                chatRoot.embeddedData.twitchBadges = new List<EmbedChatBadge>();
             }
-            Console.WriteLine("TwitchBadges: Before " + chatRoot.emotes.twitchBadges.Count);
+            Console.WriteLine("Input twitch badge count: " + chatRoot.embeddedData.twitchBadges.Count);
             List<ChatBadge> twitchBadges = new List<ChatBadge>();
-            twitchBadges = Task.Run(() => TwitchHelper.GetChatBadges(chatRoot.streamer.id, cacheFolder, embededEmotes: chatRoot.emotes)).Result;
+            twitchBadges = Task.Run(() => TwitchHelper.GetChatBadges(chatRoot.streamer.id, cacheFolder, embededData: chatRoot.embeddedData)).Result;
             foreach (ChatBadge badge in twitchBadges)
             {
                 EmbedChatBadge newBadge = new EmbedChatBadge();
                 newBadge.name = badge.Name;
                 newBadge.versions = badge.VersionsData;
-                chatRoot.emotes.twitchBadges.Add(newBadge);
+                chatRoot.embeddedData.twitchBadges.Add(newBadge);
             }
-            Console.WriteLine("TwitchBadges: After " + chatRoot.emotes.twitchBadges.Count);
+            Console.WriteLine("Output twitch badge count: " + chatRoot.embeddedData.twitchBadges.Count);
 
             // Twitch bits / cheers
-            if (chatRoot.emotes.twitchBits == null || inputOptions.UpdateOldEmotes)
+            if (chatRoot.embeddedData.twitchBits == null || inputOptions.UpdateOldEmbeds)
             {
-                chatRoot.emotes.twitchBits = new List<EmbedCheerEmote>();
+                chatRoot.embeddedData.twitchBits = new List<EmbedCheerEmote>();
             }
-            Console.WriteLine("TwitchBits: Before " + chatRoot.emotes.twitchBits.Count);
+            Console.WriteLine("Input twitch bit count: " + chatRoot.embeddedData.twitchBits.Count);
             List<CheerEmote> twitchBits = new List<CheerEmote>();
-            twitchBits = Task.Run(() => TwitchHelper.GetBits(cacheFolder, chatRoot.streamer.id.ToString(), embededEmotes: chatRoot.emotes)).Result;
+            twitchBits = Task.Run(() => TwitchHelper.GetBits(cacheFolder, chatRoot.streamer.id.ToString(), embededData: chatRoot.embeddedData)).Result;
             foreach (CheerEmote bit in twitchBits)
             {
                 EmbedCheerEmote newBit = new EmbedCheerEmote();
@@ -175,9 +146,9 @@ namespace TwitchDownloaderCLI.Modes
                     newEmote.height = emotePair.Value.Height / emotePair.Value.ImageScale;
                     newBit.tierList.Add(emotePair.Key, newEmote);
                 }
-                chatRoot.emotes.twitchBits.Add(newBit);
+                chatRoot.embeddedData.twitchBits.Add(newBit);
             }
-            Console.WriteLine("TwitchBits: After " + chatRoot.emotes.twitchBits.Count);
+            Console.WriteLine("Input twitch bit count: " + chatRoot.embeddedData.twitchBits.Count);
 
             // Finally save the output to file!
             // TODO: maybe in the future we could also export as HTML here too?
@@ -190,6 +161,8 @@ namespace TwitchDownloaderCLI.Modes
                 }
             }
 
+            if (Directory.Exists(cacheFolder))
+                Directory.Delete(cacheFolder, true);
         }
     }
 }

--- a/TwitchDownloaderCLI/Modes/DownloadChatUpdater.cs
+++ b/TwitchDownloaderCLI/Modes/DownloadChatUpdater.cs
@@ -61,6 +61,7 @@ namespace TwitchDownloaderCLI.Modes
 
             string cacheFolder = Path.Combine(string.IsNullOrWhiteSpace(inputOptions.TempFolder) ? Path.GetTempPath() : inputOptions.TempFolder, "TwitchDownloader", "chatupdatecache");
 
+            // Clear working directory if it already exists
             if (Directory.Exists(cacheFolder))
                 Directory.Delete(cacheFolder, true);
 
@@ -71,7 +72,7 @@ namespace TwitchDownloaderCLI.Modes
             }
             Console.WriteLine("Input third party emote count: " + chatRoot.embeddedData.thirdParty.Count);
             List<TwitchEmote> thirdPartyEmotes = new List<TwitchEmote>();
-            thirdPartyEmotes = Task.Run(() => TwitchHelper.GetThirdPartyEmotes(chatRoot.streamer.id, cacheFolder, bttv: inputOptions.BttvEmotes, ffz: inputOptions.FfzEmotes, stv: inputOptions.StvEmotes, embededData: chatRoot.embeddedData)).Result;
+            thirdPartyEmotes = Task.Run(() => TwitchHelper.GetThirdPartyEmotes(chatRoot.streamer.id, cacheFolder, bttv: inputOptions.BttvEmotes, ffz: inputOptions.FfzEmotes, stv: inputOptions.StvEmotes, embeddedData: chatRoot.embeddedData)).Result;
             foreach (TwitchEmote emote in thirdPartyEmotes)
             {
                 EmbedEmoteData newEmote = new EmbedEmoteData();
@@ -92,7 +93,7 @@ namespace TwitchDownloaderCLI.Modes
             }
             Console.WriteLine("Input first party emote count: " + chatRoot.embeddedData.firstParty.Count);
             List<TwitchEmote> firstPartyEmotes = new List<TwitchEmote>();
-            firstPartyEmotes = Task.Run(() => TwitchHelper.GetEmotes(chatRoot.comments, cacheFolder, embededData: chatRoot.embeddedData)).Result;
+            firstPartyEmotes = Task.Run(() => TwitchHelper.GetEmotes(chatRoot.comments, cacheFolder, embeddedData: chatRoot.embeddedData)).Result;
             foreach (TwitchEmote emote in firstPartyEmotes)
             {
                 EmbedEmoteData newEmote = new EmbedEmoteData();
@@ -112,7 +113,7 @@ namespace TwitchDownloaderCLI.Modes
             }
             Console.WriteLine("Input twitch badge count: " + chatRoot.embeddedData.twitchBadges.Count);
             List<ChatBadge> twitchBadges = new List<ChatBadge>();
-            twitchBadges = Task.Run(() => TwitchHelper.GetChatBadges(chatRoot.streamer.id, cacheFolder, embededData: chatRoot.embeddedData)).Result;
+            twitchBadges = Task.Run(() => TwitchHelper.GetChatBadges(chatRoot.streamer.id, cacheFolder, embeddedData: chatRoot.embeddedData)).Result;
             foreach (ChatBadge badge in twitchBadges)
             {
                 EmbedChatBadge newBadge = new EmbedChatBadge();
@@ -129,7 +130,7 @@ namespace TwitchDownloaderCLI.Modes
             }
             Console.WriteLine("Input twitch bit count: " + chatRoot.embeddedData.twitchBits.Count);
             List<CheerEmote> twitchBits = new List<CheerEmote>();
-            twitchBits = Task.Run(() => TwitchHelper.GetBits(cacheFolder, chatRoot.streamer.id.ToString(), embededData: chatRoot.embeddedData)).Result;
+            twitchBits = Task.Run(() => TwitchHelper.GetBits(cacheFolder, chatRoot.streamer.id.ToString(), embeddedData: chatRoot.embeddedData)).Result;
             foreach (CheerEmote bit in twitchBits)
             {
                 EmbedCheerEmote newBit = new EmbedCheerEmote();
@@ -161,6 +162,7 @@ namespace TwitchDownloaderCLI.Modes
                 }
             }
 
+            // Clear our working directory, it's highly unlikely we would reuse it anyways
             if (Directory.Exists(cacheFolder))
                 Directory.Delete(cacheFolder, true);
         }

--- a/TwitchDownloaderCLI/Program.cs
+++ b/TwitchDownloaderCLI/Program.cs
@@ -32,12 +32,10 @@ namespace TwitchDownloaderCLI
             }
 
             string[] preParsedArgs;
-            if (args.Any(x => x.Equals("-m") || x.Equals("--mode")))
+            if (args.Any(x => x is "-m" or "--mode" or "--embed-emotes"))
             {
-                // Old -m/--mode syntax was used, print an info message and convert to verb syntax
-                Console.WriteLine("[INFO] The program has switched from --mode <mode> to verbs (like \"git <verb>\"), consider using verbs instead." +
-                    " Run \"{0} help\" for more information.", processFileName);
-                preParsedArgs = PreParseArgs.Process(PreParseArgs.ConvertFromOldSyntax(args));
+                // A legacy syntax was used, convert to new syntax
+                preParsedArgs = PreParseArgs.Process(PreParseArgs.ConvertFromOldSyntax(args, processFileName));
             }
             else
             {

--- a/TwitchDownloaderCLI/README.md
+++ b/TwitchDownloaderCLI/README.md
@@ -5,6 +5,7 @@ A cross platform command line tool that can do the main functions of the GUI pro
  - [Arguments for mode clipdownload](#arguments-for-mode-clipdownload)
  - [Arguments for mode chatdownload](#arguments-for-mode-chatdownload)
  - [Arguments for mode chatrender](#arguments-for-mode-chatrender)
+ - [Arguments for mode chatupdate](#arguments-for-mode-chatupdate)
  - [Arguments for mode ffmpeg](#arguments-for-mode-ffmpeg)
  - [Arguments for mode cache](#arguments-for-mode-cache)
  - [Example commands](#example-commands)
@@ -73,17 +74,17 @@ Time in seconds to crop beginning. For example if I had a 10 second stream but o
 **-e/-\-ending**
 Time in seconds to crop ending. For example if I had a 10 second stream but only wanted the first 4 seconds of it I would use `-e 4` to end on the 4th second.
 
-**-E/-\-embed-emotes**
-(Default: false) Embeds emotes into the JSON file so in the future when an emote is removed from Twitch or a 3rd party, it will still render correctly. Useful for archival purposes, file size will be larger.
+**-E/-\-embed-images**
+(Default: false) Embed first party emotes, badges, and cheermotes into the download file for offline rendering. Useful for archival purposes, file size will be larger.
 
 **-\-bttv**
-(Default: true) BTTV emote embedding. Requires `-E / --embed-emotes`.
+(Default: true) BTTV emote embedding. Requires `-E / --embed-images`.
 
 **-\-ffz**
-(Default: true) FFZ emote embedding. Requires `-E / --embed-emotes`.
+(Default: true) FFZ emote embedding. Requires `-E / --embed-images`.
 
 **-\-stv**
-(Default: true) 7TV emote embedding. Requires `-E / --embed-emotes`.
+(Default: true) 7TV emote embedding. Requires `-E / --embed-images`.
 
 **-\-timestamp**
 (Default: false) Enable timestamps
@@ -162,7 +163,7 @@ File the program will output to.
 (Default: 0.2) Time in seconds to update chat render output.
 
 **-\-input-args**
- (Default: -framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -) Input (pass1) arguments for ffmpeg chat render.
+(Default: -framerate {fps} -f rawvideo -analyzeduration {max_int} -probesize {max_int} -pix_fmt bgra -video_size {width}x{height} -i -) Input (pass1) arguments for ffmpeg chat render.
 
 **-\-output-args**
 (Default: -c:v libx264 -preset veryfast -crf 18 -pix_fmt yuv420p "{save_path}") Output (pass2) arguments for ffmpeg chat render.
@@ -182,8 +183,38 @@ Predictions = `32`,
 NoAudioVisual = `64`,
 PrimeGaming = `128`
 
+**-\-offline**
+Render completely offline, using only resources embedded emotes, badges, and bits in the input json.
+
 **-\-ffmpeg-path**
 Path to ffmpeg executable.
+
+**-\-temp-path**
+Path to temporary folder for cache.
+
+
+## Arguments for mode chatupdate
+
+**-i/-\-input (REQUIRED)**
+Path to input file. Valid extensions are json
+
+**-o/-\-output (REQUIRED)**
+Path to output file. Extension should match the input.
+
+**-E/-\-embed-missing**
+(Default: true) Embed missing emotes, badges, and bits. Already embedded images will be untouched.
+
+**-U/-\-update-old**
+(Default: false) Update old emotes, badges, and bits to the current. All embedded images will be overwritten!
+
+**-\-bttv**
+(Default: true) Enable embedding BTTV emotes.
+
+**-\-ffz**
+(Default: true) Enable embedding FFZ emotes.
+
+**-\-stv**
+(Default: true) Enable embedding 7TV emotes.
 
 **-\-temp-path**
 Path to temporary folder for cache.
@@ -219,7 +250,7 @@ Download a Chat (plain text with timestamps)
     TwitchDownloaderCLI chatdownload --id 612942303 --timestamp-format Relative -o chat.txt
 Download a Chat (JSON with embeded emotes from Twitch and Bttv)
 
-    TwitchDownloaderCLI chatdownload --id 612942303 --embed-emotes --bttv=true --ffz=false --stv=false -o chat.json
+    TwitchDownloaderCLI chatdownload --id 612942303 --embed-images --bttv=true --ffz=false --stv=false -o chat.json
 Render a chat with defaults
 
     TwitchDownloaderCLI chatrender -i chat.json -o chat.mp4

--- a/TwitchDownloaderCLI/Tools/PreParseArgs.cs
+++ b/TwitchDownloaderCLI/Tools/PreParseArgs.cs
@@ -1,4 +1,8 @@
-﻿namespace TwitchDownloaderCLI.Tools
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TwitchDownloaderCLI.Tools
 {
     internal static class PreParseArgs
     {
@@ -10,30 +14,50 @@
         }
 
         /// <summary>
-        /// Converts an argument array that uses the old -m/--mode syntax to verb syntax
+        /// Converts an argument array that uses any legacy syntax to the current syntax
         /// </summary>
         /// <param name="args"></param>
-        /// <returns>The same <paramref name="args"/> array but using a verb instead of -m</returns>
-        internal static string[] ConvertFromOldSyntax(string[] args)
+        /// <returns>The same <paramref name="args"/> array but using current syntax instead
+        internal static string[] ConvertFromOldSyntax(string[] args, string processFileName)
         {
             int argsLength = args.Length;
-            string[] processedArgs = new string[argsLength - 1];
+            List<string> processedArgs = args.ToList();
 
-            int j = 1;
-            for (int i = 0; i < argsLength; i++)
+            if (args.Any(x => x.Equals("--embed-emotes")))
             {
-                if (args[i].Equals("-m") || args[i].Equals("--mode"))
+                Console.WriteLine("[INFO] The program has switched from --embed-emotes to --embed-images OR -E, consider using those instead. Run \'{0} help\' for more information.", processFileName);
+                for (int i = 0; i < argsLength; i++)
                 {
-                    // Copy the runmode to the verb position
-                    processedArgs[0] = args[i + 1];
-                    i++;
-                    continue;
+                    if (processedArgs[i].Equals("--embed-emotes"))
+                    {
+                        processedArgs[i] = "-E";
+                        break;
+                    }
                 }
-                processedArgs[j] = args[i];
-                j++;
             }
 
-            return processedArgs;
+            // This must always be performed last
+            if (args.Any(x => x.Equals("-m") || x.Equals("--mode")))
+            {
+                Console.WriteLine("[INFO] The program has switched from --mode <mode> to verbs (like \'git <verb>\'), consider using verbs instead. Run \'{0} help\' for more information.", processFileName);
+                int j = 1;
+                for (int i = 0; i < argsLength; i++)
+                {
+                    if (processedArgs[i].Equals("-m") || processedArgs[i].Equals("--mode"))
+                    {
+                        // Copy the runmode to the verb position
+                        processedArgs[0] = processedArgs[i + 1];
+                        i++;
+                        continue;
+                    }
+                    processedArgs[j] = processedArgs[i];
+                    j++;
+                }
+                // Remove last element as it will be a duplicate of second last element
+                processedArgs.RemoveAt(processedArgs.Count - 1);
+            }
+
+            return processedArgs.ToArray();
         }
     }
 }

--- a/TwitchDownloaderCore/Options/ChatDownloadOptions.cs
+++ b/TwitchDownloaderCore/Options/ChatDownloadOptions.cs
@@ -16,7 +16,7 @@ namespace TwitchDownloaderCore.Options
         public bool CropEnding { get; set; }
         public double CropEndingTime { get; set; }
         public bool Timestamp { get; set; }
-        public bool EmbedEmotes { get; set; }
+        public bool EmbedData { get; set; }
         public bool BttvEmotes { get; set; }
         public bool FfzEmotes { get; set; }
         public bool StvEmotes { get; set; }

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -223,15 +223,15 @@ namespace TwitchDownloaderCore
 
             return emoteReponse;
         }
-        public static async Task<List<TwitchEmote>> GetThirdPartyEmotes(int streamerId, string cacheFolder, Emotes embededEmotes = null, bool bttv = true, bool ffz = true, bool stv = true, bool offline = false)
+        public static async Task<List<TwitchEmote>> GetThirdPartyEmotes(int streamerId, string cacheFolder, EmbeddedData embededData = null, bool bttv = true, bool ffz = true, bool stv = true, bool offline = false)
         {
             List<TwitchEmote> returnList = new List<TwitchEmote>();
             List<string> alreadyAdded = new List<string>();
 
             // Load our embedded data from file
-            if (embededEmotes != null && embededEmotes.thirdParty != null)
+            if (embededData != null && embededData.thirdParty != null)
             {
-                foreach (EmbedEmoteData emoteData in embededEmotes.thirdParty)
+                foreach (EmbedEmoteData emoteData in embededData.thirdParty)
                 {
                     try
                     {
@@ -307,7 +307,7 @@ namespace TwitchDownloaderCore
             return returnList;
         }
 
-        public static async Task<List<TwitchEmote>> GetEmotes(List<Comment> comments, string cacheFolder, Emotes embededEmotes = null, bool offline = false)
+        public static async Task<List<TwitchEmote>> GetEmotes(List<Comment> comments, string cacheFolder, EmbeddedData embededData = null, bool offline = false)
         {
             List<TwitchEmote> returnList = new List<TwitchEmote>();
             List<string> alreadyAdded = new List<string>();
@@ -318,9 +318,9 @@ namespace TwitchDownloaderCore
                 TwitchHelper.CreateDirectory(emoteFolder);
 
             // Load our embedded emotes
-            if (embededEmotes != null && embededEmotes.firstParty != null)
+            if (embededData != null && embededData.firstParty != null)
             {
-                foreach (EmbedEmoteData emoteData in embededEmotes.firstParty)
+                foreach (EmbedEmoteData emoteData in embededData.firstParty)
                 {
                     try
                     {
@@ -369,15 +369,15 @@ namespace TwitchDownloaderCore
             return returnList;
         }
 
-        public static async Task<List<ChatBadge>> GetChatBadges(int streamerId, string cacheFolder, Emotes embededEmotes = null, bool offline = false)
+        public static async Task<List<ChatBadge>> GetChatBadges(int streamerId, string cacheFolder, EmbeddedData embededData = null, bool offline = false)
         {
             List<ChatBadge> returnList = new List<ChatBadge>();
             List<string> alreadyAdded = new List<string>();
 
             // Load our embedded data from file
-            if (embededEmotes != null && embededEmotes.twitchBadges != null)
+            if (embededData != null && embededData.twitchBadges != null)
             {
-                foreach (EmbedChatBadge data in embededEmotes.twitchBadges)
+                foreach (EmbedChatBadge data in embededData.twitchBadges)
                 {
                     ChatBadge newBadge = new ChatBadge(data.name, data.versions);
                     returnList.Add(newBadge);
@@ -476,15 +476,15 @@ namespace TwitchDownloaderCore
             return returnCache;
         }
 
-        public static async Task<List<CheerEmote>> GetBits(string cacheFolder, string channel_id = "", Emotes embededEmotes = null, bool offline = false)
+        public static async Task<List<CheerEmote>> GetBits(string cacheFolder, string channel_id = "", EmbeddedData embededData = null, bool offline = false)
         {
             List<CheerEmote> returnList = new List<CheerEmote>();
             List<string> alreadyAdded = new List<string>();
 
             // Load our embedded data from file
-            if (embededEmotes != null && embededEmotes.twitchBits != null)
+            if (embededData != null && embededData.twitchBits != null)
             {
-                foreach (EmbedCheerEmote data in embededEmotes.twitchBits)
+                foreach (EmbedCheerEmote data in embededData.twitchBits)
                 {
                     List<KeyValuePair<int, TwitchEmote>> tierList = new List<KeyValuePair<int, TwitchEmote>>();
                     CheerEmote newEmote = new CheerEmote() { prefix = data.prefix, tierList = tierList };

--- a/TwitchDownloaderCore/TwitchHelper.cs
+++ b/TwitchDownloaderCore/TwitchHelper.cs
@@ -223,15 +223,15 @@ namespace TwitchDownloaderCore
 
             return emoteReponse;
         }
-        public static async Task<List<TwitchEmote>> GetThirdPartyEmotes(int streamerId, string cacheFolder, EmbeddedData embededData = null, bool bttv = true, bool ffz = true, bool stv = true, bool offline = false)
+        public static async Task<List<TwitchEmote>> GetThirdPartyEmotes(int streamerId, string cacheFolder, EmbeddedData embeddedData = null, bool bttv = true, bool ffz = true, bool stv = true, bool offline = false)
         {
             List<TwitchEmote> returnList = new List<TwitchEmote>();
             List<string> alreadyAdded = new List<string>();
 
             // Load our embedded data from file
-            if (embededData != null && embededData.thirdParty != null)
+            if (embeddedData != null && embeddedData.thirdParty != null)
             {
-                foreach (EmbedEmoteData emoteData in embededData.thirdParty)
+                foreach (EmbedEmoteData emoteData in embeddedData.thirdParty)
                 {
                     try
                     {
@@ -307,7 +307,7 @@ namespace TwitchDownloaderCore
             return returnList;
         }
 
-        public static async Task<List<TwitchEmote>> GetEmotes(List<Comment> comments, string cacheFolder, EmbeddedData embededData = null, bool offline = false)
+        public static async Task<List<TwitchEmote>> GetEmotes(List<Comment> comments, string cacheFolder, EmbeddedData embeddedData = null, bool offline = false)
         {
             List<TwitchEmote> returnList = new List<TwitchEmote>();
             List<string> alreadyAdded = new List<string>();
@@ -318,9 +318,9 @@ namespace TwitchDownloaderCore
                 TwitchHelper.CreateDirectory(emoteFolder);
 
             // Load our embedded emotes
-            if (embededData != null && embededData.firstParty != null)
+            if (embeddedData != null && embeddedData.firstParty != null)
             {
-                foreach (EmbedEmoteData emoteData in embededData.firstParty)
+                foreach (EmbedEmoteData emoteData in embeddedData.firstParty)
                 {
                     try
                     {
@@ -369,15 +369,15 @@ namespace TwitchDownloaderCore
             return returnList;
         }
 
-        public static async Task<List<ChatBadge>> GetChatBadges(int streamerId, string cacheFolder, EmbeddedData embededData = null, bool offline = false)
+        public static async Task<List<ChatBadge>> GetChatBadges(int streamerId, string cacheFolder, EmbeddedData embeddedData = null, bool offline = false)
         {
             List<ChatBadge> returnList = new List<ChatBadge>();
             List<string> alreadyAdded = new List<string>();
 
             // Load our embedded data from file
-            if (embededData != null && embededData.twitchBadges != null)
+            if (embeddedData != null && embeddedData.twitchBadges != null)
             {
-                foreach (EmbedChatBadge data in embededData.twitchBadges)
+                foreach (EmbedChatBadge data in embeddedData.twitchBadges)
                 {
                     ChatBadge newBadge = new ChatBadge(data.name, data.versions);
                     returnList.Add(newBadge);
@@ -476,15 +476,15 @@ namespace TwitchDownloaderCore
             return returnCache;
         }
 
-        public static async Task<List<CheerEmote>> GetBits(string cacheFolder, string channel_id = "", EmbeddedData embededData = null, bool offline = false)
+        public static async Task<List<CheerEmote>> GetBits(string cacheFolder, string channel_id = "", EmbeddedData embeddedData = null, bool offline = false)
         {
             List<CheerEmote> returnList = new List<CheerEmote>();
             List<string> alreadyAdded = new List<string>();
 
             // Load our embedded data from file
-            if (embededData != null && embededData.twitchBits != null)
+            if (embeddedData != null && embeddedData.twitchBits != null)
             {
-                foreach (EmbedCheerEmote data in embededData.twitchBits)
+                foreach (EmbedCheerEmote data in embeddedData.twitchBits)
                 {
                     List<KeyValuePair<int, TwitchEmote>> tierList = new List<KeyValuePair<int, TwitchEmote>>();
                     CheerEmote newEmote = new CheerEmote() { prefix = data.prefix, tierList = tierList };

--- a/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
+++ b/TwitchDownloaderCore/TwitchObjects/ChatRoot.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -109,7 +108,7 @@ public class EmbedCheerEmote
     public Dictionary<int, EmbedEmoteData> tierList { get; set; }
 }
 
-public class Emotes
+public class EmbeddedData
 {
     public List<EmbedEmoteData> thirdParty { get; set; }
     public List<EmbedEmoteData> firstParty { get; set; }
@@ -132,5 +131,5 @@ public class ChatRoot
     [JsonPropertyOrder(2)]
     public List<Comment> comments { get; set; }
     [JsonPropertyOrder(3)]
-    public Emotes emotes { get; set; }
+    public EmbeddedData embeddedData { get; set; }
 }

--- a/TwitchDownloaderWPF/PageChatDownload.xaml.cs
+++ b/TwitchDownloaderWPF/PageChatDownload.xaml.cs
@@ -211,7 +211,7 @@ namespace TwitchDownloaderWPF
 				options.DownloadFormat = DownloadFormat.Text;
 
 			options.Timestamp = true;
-			options.EmbedEmotes = (bool)checkEmbed.IsChecked;
+			options.EmbedData = (bool)checkEmbed.IsChecked;
 			options.BttvEmotes = (bool)checkBttvEmbed.IsChecked;
 			options.FfzEmotes = (bool)checkFfzEmbed.IsChecked;
 			options.StvEmotes = (bool)checkStvEmbed.IsChecked;

--- a/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
+++ b/TwitchDownloaderWPF/WindowQueueOptions.xaml.cs
@@ -111,7 +111,7 @@ namespace TwitchDownloader
                                 chatOptions.DownloadFormat = DownloadFormat.Html;
                             else
                                 chatOptions.DownloadFormat = DownloadFormat.Text;
-                            chatOptions.EmbedEmotes = (bool)checkEmbed.IsChecked;
+                            chatOptions.EmbedData = (bool)checkEmbed.IsChecked;
                             chatOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, downloadTask.Info.Title, chatOptions.Id, vodPage.currentVideoTime, vodPage.textStreamer.Text) + "." + chatOptions.DownloadFormat);
 
                             if (downloadOptions.CropBeginning)
@@ -200,7 +200,7 @@ namespace TwitchDownloader
                             else
                                 chatOptions.DownloadFormat = DownloadFormat.Text;
                             chatOptions.TimeFormat = TimestampFormat.Relative;
-                            chatOptions.EmbedEmotes = (bool)checkEmbed.IsChecked;
+                            chatOptions.EmbedData = (bool)checkEmbed.IsChecked;
                             chatOptions.Filename = Path.Combine(folderPath, MainWindow.GetFilename(Settings.Default.TemplateChat, downloadTask.Info.Title, chatOptions.Id, clipPage.currentVideoTime, clipPage.textStreamer.Text) + "." + chatOptions.FileExtension);
 
                             chatTask.DownloadOptions = chatOptions;
@@ -378,7 +378,7 @@ namespace TwitchDownloader
                                     downloadOptions.DownloadFormat = DownloadFormat.Html;
                                 else
                                     downloadOptions.DownloadFormat = DownloadFormat.Text;
-                                downloadOptions.EmbedEmotes = (bool)checkEmbed.IsChecked;
+                                downloadOptions.EmbedData = (bool)checkEmbed.IsChecked;
                                 downloadOptions.TimeFormat = TimestampFormat.Relative;
                                 downloadOptions.Id = dataList[i].Id;
                                 downloadOptions.CropBeginning = false;


### PR DESCRIPTION
- Renamed `emotes` json property to `embededData`
- Added fallback for reading older jsons using `emotes` property
- Renamed `--embed-emotes` download arg to `--embed-images`
- Added syntax conversion for `--embed-emotes`
- Make chatupdater obey custom temp path
- Clear chatupdater cache after completion as it likely won't be reused
- Update README
- Complete some TODOs
- Fixed typos